### PR TITLE
feat: allow the proxmox node name to be set in build.conf

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -32,6 +32,8 @@ function die_var_unset {
 source $build_conf
 
 [[ -z "$vm_default_user" ]] && die_var_unset "vm_default_user"
+[[ -z "$vm_memory" ]] && die_var_unset "vm_memory"
+[[ -z "$proxmox_host" ]] && die_var_unset "proxmox_host"
 [[ -z "$default_vm_id" ]] && die_var_unset "default_vm_id"
 [[ -z "$iso_url" ]] && die_var_unset "iso_url"
 [[ -z "$iso_sha256_url" ]] && die_var_unset "iso_sha256_url"

--- a/debian-10-amd64-proxmox/build.conf
+++ b/debian-10-amd64-proxmox/build.conf
@@ -2,6 +2,7 @@ vm_default_user=christian
 vm_memory=1024
 default_vm_id=33000 # default VM ID for Debian
 proxmox_url=https://proxmox.lightinasia.site:8006/api2/json
+proxmox_host=proxmox
 
 iso_url=http://cdimage.debian.org/cdimage/release/current/amd64/iso-cd/debian-10.3.0-amd64-netinst.iso
 iso_sha256_url=https://cdimage.debian.org/debian-cd/current/amd64/iso-cd/SHA256SUMS

--- a/debian-10-amd64-proxmox/debian-10-amd64-proxmox.json
+++ b/debian-10-amd64-proxmox/debian-10-amd64-proxmox.json
@@ -40,7 +40,7 @@
             "cores": "2",
             "os": "l26",
             "http_directory": "http",
-            "node": "proxmox",
+            "node": "{{env `proxmox_host`}}",
             "network_adapters": [
               {
                 "model": "virtio",

--- a/openbsd-6-amd64-proxmox/build.conf
+++ b/openbsd-6-amd64-proxmox/build.conf
@@ -2,6 +2,7 @@ vm_default_user=christian
 vm_memory=1024
 default_vm_id=39000 # default VM ID for OpenBSD
 proxmox_url=https://proxmox.lightinasia.site:8006/api2/json
+proxmox_host=proxmox
 
 iso_url=https://cloudflare.cdn.openbsd.org/pub/OpenBSD/6.6/amd64/install66.iso
 iso_sha256_url=https://cloudflare.cdn.openbsd.org/pub/OpenBSD/6.6/amd64/SHA256

--- a/openbsd-6-amd64-proxmox/openbsd-6-amd64-proxmox.json
+++ b/openbsd-6-amd64-proxmox/openbsd-6-amd64-proxmox.json
@@ -41,7 +41,7 @@
             "os": "other",
             "http_directory": "http",
 
-            "node": "proxmox",
+            "node": "{{env `proxmox_host`}}",
             "network_adapters": [
               {
                 "model": "virtio",

--- a/ubuntu-18.04-amd64-proxmox/build.conf
+++ b/ubuntu-18.04-amd64-proxmox/build.conf
@@ -2,6 +2,7 @@ vm_default_user=christian
 vm_memory=1024
 default_vm_id=34000 # default VM ID for Ubuntu
 proxmox_url=https://proxmox.lightinasia.site:8006/api2/json
+proxmox_host=proxmox
 
 iso_url=http://cdimage.ubuntu.com/releases/18.04.4/release/ubuntu-18.04.4-server-amd64.iso
 iso_sha256_url=http://cdimage.ubuntu.com/releases/18.04.4/release/SHA256SUMS

--- a/ubuntu-18.04-amd64-proxmox/ubuntu-18.04-amd64-proxmox.json
+++ b/ubuntu-18.04-amd64-proxmox/ubuntu-18.04-amd64-proxmox.json
@@ -41,7 +41,7 @@
             "os": "l26",
             "http_directory": "http",
 
-            "node": "proxmox",
+            "node": "{{env `proxmox_host`}}",
             "network_adapters": [
               {
                 "model": "virtio",

--- a/ubuntu-20.04-amd64-proxmox/build.conf
+++ b/ubuntu-20.04-amd64-proxmox/build.conf
@@ -2,6 +2,7 @@ vm_default_user=christian
 vm_memory=1024
 default_vm_id=34400 # default VM ID for Ubuntu
 proxmox_url=https://proxmox.lightinasia.site:8006/api2/json
+proxmox_host=proxmox
 
 iso_url=http://cdimage.ubuntu.com/ubuntu-legacy-server/releases/20.04/release/ubuntu-20.04-legacy-server-amd64.iso
 iso_sha256_url=http://cdimage.ubuntu.com/ubuntu-legacy-server/releases/20.04/release/SHA256SUMS

--- a/ubuntu-20.04-amd64-proxmox/ubuntu-20.04-amd64-proxmox.json
+++ b/ubuntu-20.04-amd64-proxmox/ubuntu-20.04-amd64-proxmox.json
@@ -41,7 +41,7 @@
             "os": "l26",
             "http_directory": "http",
 
-            "node": "proxmox",
+            "node": "{{env `proxmox_host`}}",
             "network_adapters": [
               {
                 "model": "virtio",


### PR DESCRIPTION
My proxmox nodes are named pve#, and I think I noticed another fork had the same issue.
I also added the vm_memory to build.sh, it doesn't seem to be used currently. Please correct me if I'm wrong :) 